### PR TITLE
ADE images fix

### DIFF
--- a/ade/Dockerfile
+++ b/ade/Dockerfile
@@ -1,6 +1,6 @@
 FROM clefos/ibmjava
 
-MAINTAINER	"The ClefOS Project" <neale@sinenomine.net>
+LABEL     maintainer="The ClefOS Project <neale@sinenomine.net>"
 LABEL 		Vendor="ClefOS" License="GPLv2" 
 
 ENV 		JAVA_HOME=/opt/ibm/java PATH=$PATH:$JAVA_HOME/bin JAVA_CLASSPATH=$JAVA_CLASSPATH:$JAVA_HOME:lib
@@ -27,7 +27,7 @@ RUN		yum install --setopt=tsflags=nodocs ade mariadb mariadb-java-client supervi
 		rm -rf /var/cache/yum/* /tmp/* /var/log/yum.log
 
 # copy cfg files:
-ADD		./cfg_files/ade.tar /
+ADD		./cfg_files/etc/init.d/sshd /etc/init.d/
 
 # set up env:
 RUN 		chmod +x /etc/init.d/sshd && \


### PR DESCRIPTION
There was an error when building the image. `make ade` was failing. Also, Docker's "MAINTAINER" instruction changed as it is deprecated.